### PR TITLE
Dialog class updated to use Factory pattern

### DIFF
--- a/app/Canvas.js
+++ b/app/Canvas.js
@@ -31,9 +31,16 @@ module.exports = class Canvas {
   }
 
   addObj() {
-    Dialog.warning();
+    let dialog = Dialog.dialog();
+
+    const ackButton = document.createElement('button');
+    $(ackButton).attr('class', 'acknowledge');
+    $(ackButton).html('OK');
+    $(ackButton).click(function() { this.closest('.dialog').remove(); });
+    dialog.appendChild(ackButton);
+
     let myNotification = new Notification('Title', {
-      body: 'Lorem Ipsum Dolor Sit Amet'
+      body: 'username: ' + require('username').sync()
     });
 
     myNotification.onclick = () => {
@@ -42,14 +49,14 @@ module.exports = class Canvas {
   };
 
   displayVersion() {
-    let dialog = Dialog.notice();
+    let dialog = Dialog.notice({height: '300px', width: '400px'});
     let remoteApp = require('electron').remote.app;
 
     const logo = document.createElement('img');
     const versionText = document.createElement('div');
 
-    $(logo).attr('class', 'logo');
-    $(versionText).attr('class', 'versions');
+    $(logo).attr('id', 'version_logo');
+    $(versionText).attr('id', 'version_text');
     $(versionText).html(
       remoteApp.getName() + ' ' + remoteApp.getVersion() + '<br/>' +
       '<span id=\'frameworks\'>' +

--- a/app/Dialog.js
+++ b/app/Dialog.js
@@ -7,15 +7,19 @@ module.exports = {
     height = '300px',
     width = '400px'
   } = {}) => {
+    const overlay = document.createElement('div');
+    $(overlay).attr('class', 'overlay');
+
     const dialog = document.createElement('div');
     $(dialog).attr('class', 'dialog').height(height).width(width);
 
     const closeButton = document.createElement('button');
     $(closeButton).attr('class', 'close');
-    $(closeButton).click(function() { this.closest('.dialog').remove(); });
+    $(closeButton).click(function() { this.closest('.overlay').remove(); });
 
     dialog.appendChild(closeButton);
-    document.body.appendChild(dialog);
+    overlay.appendChild(dialog);
+    document.body.appendChild(overlay);
     return dialog;
   },
 

--- a/app/Dialog.js
+++ b/app/Dialog.js
@@ -2,38 +2,50 @@
 
 module.exports = {
 
+  // non-modal, non-interactive dialog for application notices
   notice: ({
     height = '300px',
-    width = '400px',
-    modal = false
+    width = '400px'
   } = {}) => {
     const dialog = document.createElement('div');
     $(dialog).attr('class', 'dialog').height(height).width(width);
-    if (modal) $(dialog).draggable();
+
     const closeButton = document.createElement('button');
     $(closeButton).attr('class', 'close');
     $(closeButton).click(function() { this.closest('.dialog').remove(); });
+
     dialog.appendChild(closeButton);
     document.body.appendChild(dialog);
     return dialog;
   },
 
-  warning: ({
-    height = '200px',
-    width = '300px',
+  // generic dialog for interactive dialogs that are modal by default
+  dialog: ({
+    height = '300px',
+    width = '400px',
     modal = true
   } = {}) => {
     const dialog = document.createElement('div');
     $(dialog).attr('class', 'dialog').height(height).width(width);
-    if (modal) $(dialog).draggable({ containment: 'window' });
-    const username = require('username');
-    let creator = username.sync();
+
     const closeButton = document.createElement('button');
     $(closeButton).attr('class', 'close');
     $(closeButton).click(function() { this.closest('.dialog').remove(); });
-    // TODO: Add acknowledgment button to the bottom of the warning
+
     dialog.appendChild(closeButton);
     document.body.appendChild(dialog);
+
+    if (modal) $(dialog).draggable({
+      containment: 'window',
+      start: function() {
+        $(this).css({
+          transform: 'none',
+          top: $(this).offset().top+'px',
+          left: $(this).offset().left+'px'
+        });
+      }
+    });
+
     return dialog;
   },
 

--- a/lib/index.html
+++ b/lib/index.html
@@ -11,21 +11,6 @@
     </script>
   </head>
   <body>
-    <div class="overlay">
-      <div class="loading-img"></div>
-    </div>
-
-    <div class="content">
-      <button id="button">Submit</button>
-    </div>
-
-    <script>
-      $('#button').click(function () {
-        console.log("button clicked");
-        $('.overlay').toggle();
-      });
-    </script>
-
     <button onclick="canvas.displayVersion()" class="version">Version</button>
     <button onclick="canvas.addObj()" class="test">addObj</button>
     <br />

--- a/style/canvas.css
+++ b/style/canvas.css
@@ -14,13 +14,3 @@ div.loading-img {
   top: 50%;
   transform: perspective(1px) translateY(100%);
 }
-
-div.overlay {
-  background: rgba(40, 44, 52, 0.4);
-  display: none;
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-}

--- a/style/dialog.css
+++ b/style/dialog.css
@@ -1,0 +1,41 @@
+div.dialog {
+  background: rgba(71, 0, 153, 1.0) center/20px auto no-repeat;
+  color: rgba(255, 255, 255, 1.0);
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  overflow: hidden;
+}
+
+button.close {
+  background: url('../asset/close_dark.svg') no-repeat;
+  background-size: cover;
+  height: 19px;
+  width: 19px;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  border: 0;
+  border-radius: 50%;
+  z-index: 9999;
+}
+
+button.close:hover,
+button.close:active {
+  background: url('../asset/close_active.svg') no-repeat;
+  background-size: cover;
+  cursor: pointer;
+}
+
+button.acknowledge {
+  height: 29px;
+  width: 85px;
+  color: rgba(0, 0, 0, 1.0);
+  position: absolute;
+  bottom: 20px;
+  right: 30px;
+  text-align: center;
+  font-family: 'Lato', Georgia, Serif;
+  font-size: 90%;
+}

--- a/style/dialog.css
+++ b/style/dialog.css
@@ -39,3 +39,12 @@ button.acknowledge {
   font-family: 'Lato', Georgia, Serif;
   font-size: 90%;
 }
+
+div.overlay {
+  background: rgba(40, 44, 52, 0.4);
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}

--- a/style/fonts.css
+++ b/style/fonts.css
@@ -1,0 +1,4 @@
+@@font-face {
+  font-family: 'Lato';
+  src: url('../asset/font/Lato-Light.woff');
+}

--- a/style/version.css
+++ b/style/version.css
@@ -1,15 +1,4 @@
-@@font-face {
-  font-family: 'Lato';
-  src: url('../asset/font/Lato-Light.woff');
-}
-
-#frameworks {
-  font-family: 'Lato', Georgia, Serif;
-  font-weight: 100;
-  font-size: 68%;
-}
-
-div.versions {
+div#version_text {
   display: inline-block;
   position: absolute;
   bottom: 40px;
@@ -20,37 +9,15 @@ div.versions {
   font-size: 90%;
 }
 
-div.dialog {
-  background: rgba(71, 0, 153, 1.0) center/20px auto no-repeat;
-  color: rgba(255, 255, 255, 1.0);
-  position: relative;
-  margin: auto;
-  overflow: hidden;
-}
-
-img.logo {
+img#version_logo {
   content: url('../asset/logo_full.png');
   position: relative;
   left: 50%;
   transform: translate(-50%, -15%);
 }
 
-button.close {
-  background: url('../asset/close_dark.svg') no-repeat;
-  background-size: cover;
-  height: 19px;
-  width: 19px;
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  border: 0;
-  border-radius: 50%;
-  z-index: 9999;
-}
-
-button.close:hover,
-button.close:active {
-  background: url('../asset/close_active.svg') no-repeat;
-  background-size: cover;
-  cursor: pointer;
+span#frameworks {
+  font-family: 'Lato', Georgia, Serif;
+  font-weight: 100;
+  font-size: 68%;
 }


### PR DESCRIPTION
Updated:

- `Dialog.dialog` provides generic dialog template with acknowledgement button.
- `Dialog.dialog` is modal by default.
- `Dialog.notice` uses overlay to shade the underlying canvas when active on the screen.

Notes:

- `addObj()` function in `lib/index.html` still contains a usage example of the [Notifications](https://electron.atom.io/docs/tutorial/notifications/) library in the Electron API. Not actually associated with the `Dialog` class.