### PR TITLE
Basic ApplicationMenu implementation

### DIFF
--- a/app/Menu.js
+++ b/app/Menu.js
@@ -1,0 +1,130 @@
+"use strict";
+
+define('template', [
+  {
+    label: 'Edit',
+    submenu: [
+      {role: 'undo'},
+      {role: 'redo'},
+      {type: 'separator'},
+      {role: 'cut'},
+      {role: 'copy'},
+      {role: 'paste'},
+      {role: 'pasteandmatchstyle'},
+      {role: 'delete'},
+      {role: 'selectall'}
+    ]
+  },
+  {
+    label: 'View',
+    submenu: [
+      {role: 'reload'},
+      {role: 'forcereload'},
+      {role: 'toggledevtools'},
+      {type: 'separator'},
+      {role: 'resetzoom'},
+      {role: 'zoomin'},
+      {role: 'zoomout'},
+      {type: 'separator'},
+      {role: 'togglefullscreen'}
+    ]
+  },
+  {
+    role: 'window',
+    submenu: [
+      {role: 'minimize'},
+      {role: 'close'}
+    ]
+  },
+  {
+    role: 'help',
+    submenu: [
+      {
+        label: 'Learn More',
+        click () {
+          const BrowserWindow = require('electron').BrowserWindow;
+          BrowserWindow.fromId(1).webContents.executeJavaScript(`document.querySelectorAll('.dialog').length`, function (result) {
+            console.log('dialogs: ' + result);
+          })
+          showAllBrowserWindows();
+        }
+      },
+      {
+        label: 'Find BrowserWindows',
+        click () {
+          showAllBrowserWindows();
+        }
+      },
+      {
+        label: 'About Synectic',
+        click () {
+          const BrowserWindow = require('electron').BrowserWindow;
+          BrowserWindow.fromId(1).webContents.executeJavaScript(`
+            var Canvas = require('../app/Canvas.js');
+            var canvas = new Canvas();
+            canvas.displayVersion();
+            `);
+        }
+      }
+    ]
+  }
+]);
+
+module.exports.configDarwinMenu = function () {
+  const app = require('electron').app;
+  this.template.unshift({
+    label: app.getName(),
+    submenu: [
+      {role: 'about'},
+      {type: 'separator'},
+      {role: 'services', submenu: []},
+      {type: 'separator'},
+      {role: 'hide'},
+      {role: 'hideothers'},
+      {role: 'unhide'},
+      {type: 'separator'},
+      {role: 'quit'}
+    ]
+  })
+
+  // Edit menu
+  this.template[1].submenu.push(
+    {type: 'separator'},
+    {
+      label: 'Speech',
+      submenu: [
+        {role: 'startspeaking'},
+        {role: 'stopspeaking'}
+      ]
+    }
+  )
+
+  // Window menu
+  this.template[3].submenu = [
+    {role: 'close'},
+    {role: 'minimize'},
+    {role: 'zoom'},
+    {type: 'separator'},
+    {role: 'front'}
+  ]
+};
+
+// helper function that displays all currently open BrowserWindow objects
+function showAllBrowserWindows() {
+  const BrowserWindow = require('electron').BrowserWindow;
+  var windowObjectArray = BrowserWindow.getAllWindows();
+  for (var i = 0, len = windowObjectArray.length; i < len; i ++) {
+    var windowObject = windowObjectArray[i];
+    console.log('window id: \t' + windowObject.id);
+    console.log('name: \t\t' + windowObject.__name);
+    console.log('tag: \t\t' + windowObject.__tag);
+  }
+}
+
+// helper function for defining immutable constants
+function define(name, value) {
+  Object.defineProperty(module.exports, name, {
+    value: value,
+    enumerable: true
+  });
+}

--- a/lib/index.html
+++ b/lib/index.html
@@ -5,6 +5,20 @@
     <title>synectic</title>
     <script src="init.js"></script>
     <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
+    <!-- <script>
+      const {remote} = require('electron')
+      const {Menu, MenuItem} = remote
+
+      const menu = new Menu()
+      menu.append(new MenuItem({label: 'MenuItem1', click() { console.log('item 1 clicked') }}))
+      menu.append(new MenuItem({type: 'separator'}))
+      menu.append(new MenuItem({label: 'MenuItem2', type: 'checkbox', checked: true}))
+
+      window.addEventListener('contextmenu', (e) => {
+        e.preventDefault()
+        menu.popup(remote.getCurrentWindow())
+      }, false)
+    </script> -->
     <script>
       var Canvas = require('../app/Canvas.js');
       var canvas = new Canvas();

--- a/main.js
+++ b/main.js
@@ -1,17 +1,24 @@
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, Menu } = require('electron');
 const path = require('path');
 const url = require('url');
+const menus = require('./app/Menu.js');
 
 let win;
 
 function createWindow() {
   win = new BrowserWindow({ width: 1200, height: 1000 });
+  win.__name = 'main_window';
+  win.__tag = 'main';
 
   win.loadURL(url.format({
     pathname: path.join(__dirname, 'lib/index.html'),
     protocol: 'file:',
     slashes: true,
   }));
+
+  if (process.platform === 'darwin') menus.configDarwinMenu();
+  const menu = Menu.buildFromTemplate(menus.template);
+  Menu.setApplicationMenu(menu);
 
   // Open the DevTools.
   // win.webContents.openDevTools();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1569,7 +1569,7 @@
         "commander": "2.11.0",
         "electron-window": "0.8.1",
         "fs-extra": "3.0.1",
-        "mocha": "3.4.2",
+        "mocha": "3.5.0",
         "which": "1.2.14"
       },
       "dependencies": {
@@ -3868,14 +3868,14 @@
       }
     },
     "mocha": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
-      "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
+      "integrity": "sha512-pIU2PJjrPYvYRqVpjXzj76qltO9uBYI7woYAMoxbSefsa+vqAfptjoeevd6bUgwD0mPIO+hv9f7ltvsNreL2PA==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
         "commander": "2.9.0",
-        "debug": "2.6.0",
+        "debug": "2.6.8",
         "diff": "3.2.0",
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.1",
@@ -3893,15 +3893,6 @@
           "dev": true,
           "requires": {
             "graceful-readlink": "1.0.1"
-          }
-        },
-        "debug": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-          "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
           }
         },
         "glob": {
@@ -3932,12 +3923,6 @@
           "requires": {
             "minimist": "0.0.8"
           }
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "electron-mocha": "^4.0.0",
     "electron-packager": "^8.7.2",
     "electron-prebuilt": "^1.4.13",
-    "mocha": "^3.4.2",
+    "mocha": "^3.5.0",
     "spectron": "^3.7.2"
   },
   "dependencies": {

--- a/test/app-menu-test.js
+++ b/test/app-menu-test.js
@@ -1,0 +1,34 @@
+// A test to verify the custom app menu integrates with native apps
+var Application = require('spectron').Application;
+var electron = require('electron-prebuilt');
+var assert = require('assert');
+const path = require('path');
+
+var app = new Application({
+  path: electron,
+  args: [path.join(__dirname, '..', 'main.js')],
+  webPreferences: [],
+});
+
+describe('app-menu integration', function () {
+  this.timeout(30000);
+
+  before(function () {
+    this.app = new Application({
+      path: electron,
+      args: [path.join(__dirname, '..', 'main.js')],
+    });
+    return this.app.start();
+  });
+
+  after(function () {
+    if (this.app && this.app.isRunning()) {
+      return this.app.stop();
+    }
+  });
+
+  it('check that ApplicationMenu is set', function () {
+    let menu = this.app.electron.remote.Menu.getApplicationMenu();
+    return assert.notEqual(menu, null);
+  });
+});


### PR DESCRIPTION
Added:
- `app/Menu.js` to create basic *template* `MenuItemConstructorOptions[]` constant for use with `Menu.buildFromTemplate(template)` command; i.e. setting a new ApplicationMenu.
- `test/app-menu-test.js` for validating that an ApplicationMenu has been set.

Notes:
- Example usage of code for creating a right-click menu is currently commented out in `lib/index.html`. Requires clean-up and customization to take advantage of this functionality.