### PR TITLE
Make Canvas menu and submenu items work on Linux.

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -21,7 +21,11 @@ class AppManager {
     let menu = require('../app/AppMenu.js');
     if (process.platform === 'darwin') menu.configDarwinMenu();
     applicationMenu = Menu.buildFromTemplate(menu.template);
-    canvasSelectionSubmenu = applicationMenu.items[3].submenu.items[0].submenu;
+    if (process.platform !== 'darwin') {
+      canvasSelectionSubmenu = applicationMenu.items[2].submenu.items[0].submenu;
+    } else {
+      canvasSelectionSubmenu = applicationMenu.items[3].submenu.items[0].submenu;
+    }
     Menu.setApplicationMenu(applicationMenu);
   }
 

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -21,11 +21,10 @@ class AppManager {
     let menu = require('../app/AppMenu.js');
     if (process.platform === 'darwin') menu.configDarwinMenu();
     applicationMenu = Menu.buildFromTemplate(menu.template);
-    if (process.platform !== 'darwin') {
-      canvasSelectionSubmenu = applicationMenu.items[2].submenu.items[0].submenu;
-    } else {
-      canvasSelectionSubmenu = applicationMenu.items[3].submenu.items[0].submenu;
-    }
+    canvasSelectionSubmenu = (process.platform !== 'darwin') ?
+      applicationMenu.items[2].submenu.items[0].submenu :
+      applicationMenu.items[3].submenu.items[0].submenu;
+
     Menu.setApplicationMenu(applicationMenu);
   }
 


### PR DESCRIPTION
On Mac, we have the Apple button for every app's menu. On (most) linux desktop env,
we don't need to account for that when building the menu.